### PR TITLE
New feature + fix for php 7.3

### DIFF
--- a/hdz/app/Config/App.php
+++ b/hdz/app/Config/App.php
@@ -5,6 +5,7 @@ $className = '\Config\Helpdesk';
 if(!class_exists($className)){
     die('Edit the file Helpdesk.new.php with your configuration and rename to Helpdesk.php ('.APPPATH.'Config)');
 }
+define("MAIL_DELETE", Helpdesk::MAIL_DELETE);
 class App extends Helpdesk
 {
 

--- a/hdz/app/Config/Helpdesk.new.php
+++ b/hdz/app/Config/Helpdesk.new.php
@@ -42,4 +42,7 @@ class Helpdesk extends BaseConfig
 
     #URI name to access to staff panel. Ex: staff / then you can access in http://helpdesk.com/staff
     const STAFF_URI = 'staff';
+    
+    #Delete email after IMAP fetching
+    cont MAIL_DELETE = true;
 }

--- a/hdz/app/Config/Helpdesk.new.php
+++ b/hdz/app/Config/Helpdesk.new.php
@@ -43,6 +43,6 @@ class Helpdesk extends BaseConfig
     #URI name to access to staff panel. Ex: staff / then you can access in http://helpdesk.com/staff
     const STAFF_URI = 'staff';
     
-    #Delete email after IMAP fetching
+    #Delete email after IMAP fetching, set to true to delete emails after fetching
     const MAIL_DELETE = true;
 }

--- a/hdz/app/Config/Helpdesk.new.php
+++ b/hdz/app/Config/Helpdesk.new.php
@@ -44,5 +44,5 @@ class Helpdesk extends BaseConfig
     const STAFF_URI = 'staff';
     
     #Delete email after IMAP fetching
-    cont MAIL_DELETE = true;
+    const MAIL_DELETE = true;
 }

--- a/hdz/app/Libraries/MailFetcher.php
+++ b/hdz/app/Libraries/MailFetcher.php
@@ -71,7 +71,7 @@ class MailFetcher
                             }
                         }
                     }
-                  if(Helpdesk::MAIL_DELETE == true){
+                  if(MAIL_DELETE == true){
                       $mailbox->deleteMail($mail->id);
                   }
                 }

--- a/hdz/app/Libraries/MailFetcher.php
+++ b/hdz/app/Libraries/MailFetcher.php
@@ -35,7 +35,11 @@ class MailFetcher
                     $email->imap_password // Password for the before configured username
                 );
                 try{
-                    $mailsIds = $mailbox->searchMailbox('ALL');
+                    if(MAIL_DELETE == true){
+                        $mailsIds = $mailbox->searchMailbox('ALL');
+                    }else{
+                        $mailsIds = $mailbox->searchMailbox('UNSEEN');
+                    }
                 }catch (ConnectionException $ex){
                     log_message('error','IMAP connection failed: '.$ex);
                     return false;

--- a/hdz/app/Libraries/MailFetcher.php
+++ b/hdz/app/Libraries/MailFetcher.php
@@ -71,7 +71,9 @@ class MailFetcher
                             }
                         }
                     }
-                    $mailbox->deleteMail($mail->id);
+                  if(Helpdesk::MAIL_DELETE == true){
+                      $mailbox->deleteMail($mail->id);
+                  }
                 }
                 $mailbox->disconnect();
             }

--- a/hdz/app/Views/staff/email_addresses_form.php
+++ b/hdz/app/Views/staff/email_addresses_form.php
@@ -134,11 +134,13 @@ if(isset($success_msg)){
                         </select>
                     </div>
                     <div id="incoming_details">
-                        <div class="form-group">
-                            <div class="alert alert-warning">
-                                <?php echo lang('Admin.settings.incomingInformation');?>
+                        <?php if(HELPDESK::MAIL_DELETE == true){ ?>
+                            <div class="form-group">
+                                <div class="alert alert-warning">
+                                    <?php echo lang('Admin.settings.incomingInformation');?>
+                                </div>
                             </div>
-                        </div>
+                        <?php } ?>
                         <div class="form-group">
                             <label><?php echo lang('Admin.settings.host');?></label>
                             <input type="text" name="imap_host" class="form-control" value="<?php echo set_value('imap_host', (isset($email) ? $email->imap_host : ''));?>">

--- a/hdz/app/Views/staff/email_addresses_form.php
+++ b/hdz/app/Views/staff/email_addresses_form.php
@@ -134,7 +134,7 @@ if(isset($success_msg)){
                         </select>
                     </div>
                     <div id="incoming_details">
-                        <?php if(Helpdesk::MAIL_DELETE == true){ ?>
+                        <?php if(MAIL_DELETE == true){ ?>
                             <div class="form-group">
                                 <div class="alert alert-warning">
                                     <?php echo lang('Admin.settings.incomingInformation');?>

--- a/hdz/app/Views/staff/email_addresses_form.php
+++ b/hdz/app/Views/staff/email_addresses_form.php
@@ -134,7 +134,7 @@ if(isset($success_msg)){
                         </select>
                     </div>
                     <div id="incoming_details">
-                        <?php if(HELPDESK::MAIL_DELETE == true){ ?>
+                        <?php if(Helpdesk::MAIL_DELETE == true){ ?>
                             <div class="form-group">
                                 <div class="alert alert-warning">
                                     <?php echo lang('Admin.settings.incomingInformation');?>

--- a/hdz/framework/CodeIgniter.php
+++ b/hdz/framework/CodeIgniter.php
@@ -181,7 +181,9 @@ class CodeIgniter
 	public function initialize()
 	{
 		// Set default locale on the server
-		locale_set_default($this->config->defaultLocale ?? 'en');
+		if( function_exists('locale_set_default' ) ) :
+                        locale_set_default($this->config->defaultLocale ?? 'en');
+                endif;
 
 		// Set default timezone on the server
 		date_default_timezone_set($this->config->appTimezone ?? 'UTC');


### PR DESCRIPTION
Hi, I've fixed a fatal error on php 7.3, as you can see from the commit, it just needed to check if the function exists..
I wanted to keep the emails after the imap fetching.. so, to avoid to delete a function, I've thinked to create a new const and add the check before deleting, so if you accept my pull request, anyone can choose to keep the emails. If the emails are set to stay, the warning "System will delete all emails from the mailbox once downloaded. This is done to ensure best performance for the email handling process on web server side. If you want a backup of the emails, then we recommend to create a new mailbox where you forward all incoming mails to." will disappear.
To avoid ticket duplication, if the deletion is set to false, it will avoid already seen messages during the fetch.

Have a nice day.