### PR TITLE
Set the right SMTP url for Gmail

### DIFF
--- a/hdz/app/Views/staff/email_addresses_form.php
+++ b/hdz/app/Views/staff/email_addresses_form.php
@@ -86,7 +86,7 @@ if(isset($success_msg)){
                     <div id="outgoing_details">
                         <div class="form-group">
                             <label><?php echo lang('Admin.settings.host');?></label>
-                            <input type="text" name="smtp_host" class="form-control" value="<?php echo set_value('smtp_host', (isset($email) ? $email->smtp_host : 'mail.gmail.com'));?>">
+                            <input type="text" name="smtp_host" class="form-control" value="<?php echo set_value('smtp_host', (isset($email) ? $email->smtp_host : 'smtp.gmail.com'));?>">
                         </div>
                         <div class="form-group">
                             <label><?php echo lang('Admin.settings.port');?></label>


### PR DESCRIPTION
The current one is misleading and is not really an example since it just doesn't work.